### PR TITLE
Handle UTF-8 BOM in GTFS files

### DIFF
--- a/csv.py
+++ b/csv.py
@@ -38,7 +38,7 @@ def parse(names, line):
 
 class DictReader:
     def __init__(self, f):
-        s = f.readline().strip()
+        s = f.readline()
 
         # utf-8 BOM
         if s.startswith('\ufeff'):

--- a/csv.py
+++ b/csv.py
@@ -40,6 +40,12 @@ class DictReader:
     def __init__(self, f):
         s = f.readline().strip()
 
+        # utf-8 BOM
+        if s.startswith('\ufeff'):
+            s = s[1:]
+
+        s = s.strip()
+
         self.names = s.split(',')
         self.rows = []
         self.rowIndex = 0


### PR DESCRIPTION
Some GTFS files use a UTF-8 byte order mark to signal UTF-8 encoding, although this is neither required nor recommended according to the Unicode standard.

Skip the BOM if present.